### PR TITLE
chapt9中修改gazebo启动文件

### DIFF
--- a/docs/humble/chapt9/get_started/3.在Gazebo加载机器人模型.md
+++ b/docs/humble/chapt9/get_started/3.在Gazebo加载机器人模型.md
@@ -236,7 +236,7 @@ def generate_launch_description():
 
     # Start Gazebo server
     start_gazebo_cmd =  ExecuteProcess(
-        cmd=['gazebo', '--verbose','-s', 'libgazebo_ros_init.so', '-s', 'libgazebo_ros_factory.so', gazebo_world_path],
+        cmd=['gazebo', '--verbose','-s', 'libgazebo_ros_init.so', '-s', 'libgazebo_ros_factory.so'],
         output='screen')
 
     # Launch the robot


### PR DESCRIPTION
chapt9中 3.在Gazebo加载机器人模型.md这个文件中，启动文件launch中，没有定义    gazebo_world_path 这个变量，但使用到了，可以删除这个启动使用的变量。